### PR TITLE
updated guard version

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -3,6 +3,7 @@ source 'http://rubygems.org'
 # Specify your gem's dependencies in guard-passenger.gemspec
 gemspec
 
+gem 'rake'
 require 'rbconfig'
 
 if Config::CONFIG['target_os'] =~ /darwin/i

--- a/guard-passenger.gemspec
+++ b/guard-passenger.gemspec
@@ -15,7 +15,7 @@ Gem::Specification.new do |s|
   s.required_rubygems_version = '>= 1.3.6'
   s.rubyforge_project         = 'guard-passenger'
 
-  s.add_dependency 'guard', '~> 0.3'
+  s.add_dependency 'guard', '>= 1.0.0'
 
   s.add_development_dependency 'bundler',       '~> 1.0.7'
   s.add_development_dependency 'rspec',         '~> 2.2.0'


### PR DESCRIPTION
The guard version in the gemspec was quite old.  Also I was unable to build/install without adding rake to the gemspec, I am running 1.9.2 not sure if it something specific with 1.9.2 or not.

-Dennis
