### PR TITLE
Corrects small typo in cli_stop.

### DIFF
--- a/lib/guard/passenger.rb
+++ b/lib/guard/passenger.rb
@@ -76,7 +76,7 @@ module Guard
       def cli_stop
         cmd_parts = []
         cmd_parts << "--port #{port}" if port != 3000
-        cmd_parts << "--pid_file #{pid_file}" if pid_file
+        cmd_parts << "--pid-file #{pid_file}" if pid_file
         cmd_parts.join(' ')
       end
 


### PR DESCRIPTION
The `cli_stop` method was adding `--pid_file` to the Passenger command, but Passenger expected `--pid-file`. Microscopic, but vital!
