### PR TITLE
Fix to stop standalone passenger on guard stop

### DIFF
--- a/lib/guard/passenger.rb
+++ b/lib/guard/passenger.rb
@@ -41,7 +41,7 @@ module Guard
     def start
       UI.info 'Guard::Passenger is running!'
       if standalone?
-        running = Runner.start_passenger(cli_start, @sudo)
+        @running = Runner.start_passenger(cli_start, @sudo)
       else
         true
       end


### PR DESCRIPTION
Whenever I quit guard, my passenger standalone kept running. When the passenger start for the standalone,  I noticed the variable name wasn't right, so this just fixes it.
